### PR TITLE
feat: add python embed handler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,8 @@ resolver = "2"
 members = [
     "crates/lang_handler",
     "crates/php",
-    "crates/php_node"
+    "crates/php_node",
+    "crates/python"
 ]
 
 # [profile.release]

--- a/README.md
+++ b/README.md
@@ -53,6 +53,26 @@ const response = await php.handleRequest(request)
 console.log(response.body.toString())
 ```
 
+## Python
+
+An experimental crate (`crates/python`) can execute Python scripts using [PyO3](https://pyo3.rs/).
+Requests are routed to scripts relative to a docroot and their standard output is
+returned as the response body. Node.js bindings are not yet available.
+
+```rust
+use lang_handler::RequestBuilder;
+use python::Embed;
+
+let embed = Embed::new("path/to/scripts");
+let request = RequestBuilder::new()
+  .method("GET")
+  .url("http://localhost/hello.py")
+  .build()
+  .unwrap();
+let response = embed.handle(request).unwrap();
+println!("{}", String::from_utf8_lossy(response.body()));
+```
+
 ## API
 
 ### `new Php(config)`

--- a/crates/python/Cargo.toml
+++ b/crates/python/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "python"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+lang_handler = { path = "../lang_handler" }
+pyo3 = { version = "0.21", features = ["auto-initialize"] }

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -1,0 +1,63 @@
+use std::path::{Path, PathBuf};
+
+use lang_handler::{Handler, Request, Response, ResponseBuilder};
+use pyo3::prelude::*;
+
+/// Embed a Python script environment to handle HTTP requests.
+pub struct Embed {
+  docroot: PathBuf,
+}
+
+impl Embed {
+  /// Create a new Python embed with the given document root.
+  pub fn new<C: AsRef<Path>>(docroot: C) -> Self {
+    Self {
+      docroot: docroot.as_ref().to_path_buf(),
+    }
+  }
+}
+
+impl Handler for Embed {
+  type Error = String;
+
+  fn handle(&self, request: Request) -> Result<Response, Self::Error> {
+    // Determine the path to the python script relative to docroot
+    let path = self.docroot.join(&request.url().path()[1..]);
+    let code = std::fs::read_to_string(&path)
+      .map_err(|e| format!("failed to read script: {e}"))?;
+
+    Python::with_gil(|py| -> PyResult<Response> {
+      let sys = py.import("sys")?;
+      let io = py.import("io")?;
+      let buffer: Py<PyAny> = io.getattr("StringIO")?.call0()?.into();
+      sys.setattr("stdout", buffer.bind(py))?;
+      py.run(&code, None, None)?;
+      let output: String = buffer.bind(py).call_method0("getvalue")?.extract()?;
+      let resp = ResponseBuilder::new().status(200).body(output.as_bytes()).build();
+      Ok(resp)
+    }).map_err(|e| e.to_string())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use lang_handler::{MockRootBuilder, RequestBuilder};
+
+  #[test]
+  fn runs_python_script() {
+    let docroot = MockRootBuilder::default()
+      .file("hello.py", "print('Hello, Python!')")
+      .build()
+      .unwrap();
+    let embed = Embed::new(&*docroot);
+    let request = RequestBuilder::new()
+      .method("GET")
+      .url("http://localhost/hello.py")
+      .build()
+      .unwrap();
+    let response = embed.handle(request).unwrap();
+    assert_eq!(response.status(), 200);
+    assert_eq!(response.body(), "Hello, Python!\n");
+  }
+}


### PR DESCRIPTION
## Summary
- add experimental Python handler crate using PyO3
- register Python crate in workspace
- document how to use the Python handler in the README

## Testing
- `cargo test -p python`
- `npm test` *(fails: Cannot find module './npm/linux-x64-gnu/binding.node')*


------
https://chatgpt.com/codex/tasks/task_e_6897af456ce483258c779ef26d53d313