### PR TITLE
feat: add python-node hello world demo

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,13 @@
+# Python/Node Hello World
+
+This example shows a simple Python HTTP server and a Node.js script sending a request to it.
+
+1. Start the Python server:
+   ```sh
+   python demo/python_server.py
+   ```
+2. In another terminal, run the Node.js request script:
+   ```sh
+   node demo/node_request.js
+   ```
+The Node script prints the `Hello from Python!` response.

--- a/demo/node_request.js
+++ b/demo/node_request.js
@@ -1,0 +1,11 @@
+import http from 'node:http'
+
+http.get('http://localhost:8000', res => {
+  let data = ''
+  res.on('data', chunk => { data += chunk })
+  res.on('end', () => {
+    console.log(data)
+  })
+}).on('error', err => {
+  console.error('Request failed:', err)
+})

--- a/demo/python_server.py
+++ b/demo/python_server.py
@@ -1,0 +1,13 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.end_headers()
+        self.wfile.write(b"Hello from Python!")
+
+if __name__ == "__main__":
+    with HTTPServer(("localhost", 8000), Handler) as httpd:
+        print("Serving on http://localhost:8000")
+        httpd.serve_forever()


### PR DESCRIPTION
## Summary
- add Python HTTP server
- add Node.js script sending request to Python server
- document how to run the demo

## Testing
- `npm test` *(fails: Cannot find module './npm/linux-x64-gnu/binding.node')*

------
https://chatgpt.com/codex/tasks/task_e_689aeb0feef08325a290ddcd9b10f400